### PR TITLE
Allow GmsCore to manage USB devices

### DIFF
--- a/GmsCore/privapp-permissions-com.google.android.gms.xml
+++ b/GmsCore/privapp-permissions-com.google.android.gms.xml
@@ -3,7 +3,7 @@
     <privapp-permissions package="com.google.android.gms">
         <!-- for restrictive signature spoofing, where the permission is "signature|privileged" -->
         <permission name="android.permission.FAKE_PACKAGE_SIGNATURE"/>
-
+        <permission name="android.permission.MANAGE_USB"/>
         <permission name="android.permission.INSTALL_LOCATION_PROVIDER"/>
         <permission name="android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST"/>
         <permission name="android.permission.UPDATE_APP_OPS_STATS"/>


### PR DESCRIPTION
```
08-26 02:31:01.695  1529  1529 E AndroidRuntime: *** FATAL EXCEPTION IN SYSTEM PROCESS: main
08-26 02:31:01.695  1529  1529 E AndroidRuntime: java.lang.IllegalStateException: Signature|privileged permissions not in privapp-permissions allowlist: {com.google.android.gms (/product/priv-app/GmsCore): android.permission.MANAGE_USB}
08-26 02:31:01.695  1529  1529 E AndroidRuntime: 	at com.android.server.pm.permission.PermissionManagerService.systemReady(PermissionManagerService.java:4577)
08-26 02:31:01.695  1529  1529 E AndroidRuntime: 	at com.android.server.pm.permission.PermissionManagerService.access$800(PermissionManagerService.java:191)
08-26 02:31:01.695  1529  1529 E AndroidRuntime: 	at com.android.server.pm.permission.PermissionManagerService$PermissionManagerServiceInternalImpl.onSystemReady(PermissionManagerService.java:5051)
08-26 02:31:01.695  1529  1529 E AndroidRuntime: 	at com.android.server.pm.PackageManagerService.systemReady(PackageManagerService.java:24748)
08-26 02:31:01.695  1529  1529 E AndroidRuntime: 	at com.android.server.SystemServer.startOtherServices(SystemServer.java:2626)
08-26 02:31:01.695  1529  1529 E AndroidRuntime: 	at com.android.server.SystemServer.run(SystemServer.java:883)
08-26 02:31:01.695  1529  1529 E AndroidRuntime: 	at com.android.server.SystemServer.main(SystemServer.java:614)
08-26 02:31:01.695  1529  1529 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
08-26 02:31:01.695  1529  1529 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
08-26 02:31:01.695  1529  1529 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:981)
```

Signed-off-by: Beru Hinode <windowz414@1337.lgbt>
