### PR TITLE
Add optional local libs to GmsCore for 0.2.25.223616

### DIFF
--- a/GmsCore/Android.mk
+++ b/GmsCore/Android.mk
@@ -32,5 +32,6 @@ LOCAL_OVERRIDES_PACKAGES := com.qualcomm.location
 LOCAL_REQUIRED_MODULES := privapp-permissions-com.google.android.gms.xml default-permissions-com.google.android.gms.xml sysconfig-com.google.android.gms.xml
 LOCAL_PRODUCT_MODULE := true
 LOCAL_USES_LIBRARIES := com.android.location.provider
+LOCAL_OPTIONAL_USES_LIBRARIES := androidx.window.extensions androidx.window.sidecar
 include $(BUILD_PREBUILT)
 

--- a/GmsCore/privapp-permissions-com.google.android.gms.xml
+++ b/GmsCore/privapp-permissions-com.google.android.gms.xml
@@ -7,5 +7,6 @@
         <permission name="android.permission.INSTALL_LOCATION_PROVIDER"/>
         <permission name="android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST"/>
         <permission name="android.permission.UPDATE_APP_OPS_STATS"/>
+        <permission name="android.permission.MANAGE_USB"/>
     </privapp-permissions>
 </permissions>


### PR DESCRIPTION
GmsCore 0.2.25.223616 is throwing a new error fixed by including optional libraries:

`androidx.window.extensions`
`androidx.window.sidecar`

```
[ 65% 87856/133935] Verifying uses-libraries: vendor/partner_gms/GmsCore/GmsCore.apk
FAILED: out/target/common/obj/APPS/GmsCore_intermediates/enforce_uses_libraries.status
/bin/bash -c "(rm -f out/target/common/obj/APPS/GmsCore_intermediates/enforce_uses_libraries.status ) && (build/soong/scripts/manifest_check.py 	  --enforce-uses-libraries 	  --enforce-uses-libraries-status out/target/common/obj/APPS/GmsCore_intermediates/enforce_uses_libraries.status 	  --aapt out/host/linux-x86/bin/aapt 	  --uses-library com.android.location.provider 	   	  --dexpreopt-config out/target/product/herolte/obj/JAVA_LIBRARIES/com.android.location.provider_intermediates/dexpreopt.config 	   	  vendor/partner_gms/GmsCore/GmsCore.apk )"
error: mismatch in the <uses-library> tags between the build system and the manifest:
	- required libraries in build system: [com.android.location.provider]
	                 vs. in the manifest: [com.android.location.provider]
	- optional libraries in build system: []
	                 vs. in the manifest: [androidx.window.extensions, androidx.window.sidecar]
	- tags in the manifest (vendor/partner_gms/GmsCore/GmsCore.apk):
		uses-library:'com.android.location.provider'		uses-library-not-required:'androidx.window.extensions'		uses-library-not-required:'androidx.window.sidecar'
note: the following options are available:
	- to temporarily disable the check on command line, rebuild with RELAX_USES_LIBRARY_CHECK=true (this will set compiler filter "verify" and disable AOT-compilation in dexpreopt)
	- to temporarily disable the check for the whole product, set PRODUCT_BROKEN_VERIFY_USES_LIBRARIES := true in the product makefiles
	- to fix the check, make build system properties coherent with the manifest
	- for details, see build/make/Changes.md and https://source.android.com/devices/tech/dalvik/art-class-loader-context
```