### PR TITLE
Use the `math_gt_or_eq` conditional to fix pre-19.1 builds

### DIFF
--- a/GmsCore/Android.mk
+++ b/GmsCore/Android.mk
@@ -30,8 +30,10 @@ LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)
 LOCAL_CERTIFICATE := PRESIGNED
 LOCAL_OVERRIDES_PACKAGES := com.qualcomm.location
 LOCAL_REQUIRED_MODULES := privapp-permissions-com.google.android.gms.xml default-permissions-com.google.android.gms.xml sysconfig-com.google.android.gms.xml
-LOCAL_PRODUCT_MODULE := true
+# these lines will break builds before 19.1 so make them conditional
+ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 31),)
 LOCAL_USES_LIBRARIES := com.android.location.provider
 LOCAL_OPTIONAL_USES_LIBRARIES := androidx.window.extensions androidx.window.sidecar
+endif
+LOCAL_PRODUCT_MODULE := true
 include $(BUILD_PREBUILT)
-


### PR DESCRIPTION
This should fix #17 `Changes for LOS 19 have broken LOS 18 builds`

Test by using this fix to make 
-
- [x] 18.1 build 
- [x] 19.1 build