### PR TITLE
Add legacy apache http lib as optional lib for GmsCore

### DIFF
--- a/GmsCore/Android.mk
+++ b/GmsCore/Android.mk
@@ -33,7 +33,7 @@ LOCAL_REQUIRED_MODULES := privapp-permissions-com.google.android.gms.xml default
 # these lines will break builds before 19.1 so make them conditional
 ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 31),)
 LOCAL_USES_LIBRARIES := com.android.location.provider
-LOCAL_OPTIONAL_USES_LIBRARIES := androidx.window.extensions androidx.window.sidecar
+LOCAL_OPTIONAL_USES_LIBRARIES := org.apache.http.legacy androidx.window.extensions androidx.window.sidecar
 endif
 LOCAL_PRODUCT_MODULE := true
 include $(BUILD_PREBUILT)


### PR DESCRIPTION
My build was failing due to the updated GmsCore apk, since the Android.mk file had not been updated. This change fixes the related build error.