### PR TITLE
FDroid: Declare optional libraries w/o risk of breaking pre-19.1 builds

### DIFF
--- a/FDroid/Android.mk
+++ b/FDroid/Android.mk
@@ -5,5 +5,9 @@ LOCAL_SRC_FILES := FDroid.apk
 LOCAL_MODULE_CLASS := APPS
 LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)
 LOCAL_CERTIFICATE := PRESIGNED
+# these lines may break builds before 19.1 so make them conditional
+ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 31),)
+LOCAL_OPTIONAL_USES_LIBRARIES := androidx.window.extensions androidx.window.sidecar
+endif
 LOCAL_PRODUCT_MODULE := true
 include $(BUILD_PREBUILT)


### PR DESCRIPTION
My own 20.0 build was failing after [Update FDroid to 1.16.1](https://github.com/lineageos4microg/android_vendor_partner_gms/commit/bcae0adba1dcd7cb7e98428d18d4e5169d2d535b):
> FAILED: Verifying uses-libraries: prebuilts/prebuiltapks/FDroid/FDroid.apk
> Outputs: out/target/common/obj/APPS/FDroid_intermediates/enforce_uses_libraries.status
> Error: exited with code: 1
> Command: /bin/bash -c "(rm -f out/target/common/obj/APPS/FDroid_intermediates/enforce_uses_libraries.status ) && (build/soong/scripts/manifest_check.py           --enforce-uses-libraries    --enforce-uses-libraries-status out/target/common/obj/APPS/FDroid_intermediates/enforce_uses_libraries.status         --aapt out/host/linux-x86/bin/aapt                                      prebuilts/prebuiltapks/FDroid/FDroid.apk )"
> Output:
> error: mismatch in the <uses-library> tags between the build system and the manifest:
>         - required libraries in build system: []
>                          vs. in the manifest: []
>         - optional libraries in build system: []
>                          vs. in the manifest: [androidx.window.extensions, androidx.window.sidecar]
>         - tags in the manifest (prebuilts/prebuiltapks/FDroid/FDroid.apk):
>                 uses-library-not-required:'androidx.window.extensions'          uses-library-not-required:'androidx.window.sidecar'
> note: the following options are available:
>         - to temporarily disable the check on command line, rebuild with RELAX_USES_LIBRARY_CHECK=true (this will set compiler filter "verify" and disable AOT-compilation in dexpreopt)
>         - to temporarily disable the check for the whole product, set PRODUCT_BROKEN_VERIFY_USES_LIBRARIES := true in the product makefiles
>         - to fix the check, make build system properties coherent with the manifest
>         - for details, see build/make/Changes.md and https://source.android.com/devices/tech/dalvik/art-class-loader-context
> 
This change fixes the related build error and does not take any risks regarding pre-19.1 builds similar to [Use the math_gt_or_eq conditional to fix pre-19.1 builds](https://github.com/lineageos4microg/android_vendor_partner_gms/commit/0ec7fb7bccae82cb66582ceb14c59c3620fb309f).