### PR TITLE
Sort out permissions for updated microG GmsCore

### DIFF
--- a/GmsCore/Android.mk
+++ b/GmsCore/Android.mk
@@ -3,6 +3,7 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 LOCAL_MODULE := privapp-permissions-com.google.android.gms.xml
 LOCAL_MODULE_CLASS := ETC
+LOCAL_PRODUCT_MODULE := true
 LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT_ETC)/permissions
 LOCAL_SRC_FILES := $(LOCAL_MODULE)
 include $(BUILD_PREBUILT)
@@ -10,6 +11,7 @@ include $(BUILD_PREBUILT)
 include $(CLEAR_VARS)
 LOCAL_MODULE := default-permissions-com.google.android.gms.xml
 LOCAL_MODULE_CLASS := ETC
+LOCAL_PRODUCT_MODULE := true
 LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT_ETC)/default-permissions
 LOCAL_SRC_FILES := $(LOCAL_MODULE)
 include $(BUILD_PREBUILT)
@@ -22,18 +24,28 @@ LOCAL_SRC_FILES := $(LOCAL_MODULE)
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := microg.xml
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_ETC)/
+LOCAL_SRC_FILES := $(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE := GmsCore
 LOCAL_SRC_FILES := GmsCore.apk
 LOCAL_MODULE_CLASS := APPS
+LOCAL_PRODUCT_MODULE := true
 LOCAL_PRIVILEGED_MODULE := true
 LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)
 LOCAL_CERTIFICATE := PRESIGNED
 LOCAL_OVERRIDES_PACKAGES := com.qualcomm.location
-LOCAL_REQUIRED_MODULES := privapp-permissions-com.google.android.gms.xml default-permissions-com.google.android.gms.xml sysconfig-com.google.android.gms.xml
+LOCAL_REQUIRED_MODULES := privapp-permissions-com.google.android.gms.xml default-permissions-com.google.android.gms.xml sysconfig-com.google.android.gms.xml microg.xml
 # these lines will break builds before 19.1 so make them conditional
 ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 31),)
 LOCAL_USES_LIBRARIES := com.android.location.provider
 LOCAL_OPTIONAL_USES_LIBRARIES := org.apache.http.legacy androidx.window.extensions androidx.window.sidecar
 endif
 LOCAL_PRODUCT_MODULE := true
+LOCAL_DEX_PREOPT := false
 include $(BUILD_PREBUILT)

--- a/GmsCore/default-permissions-com.google.android.gms.xml
+++ b/GmsCore/default-permissions-com.google.android.gms.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <exceptions>
     <exception package="com.google.android.gms">
-        <!-- for permissive signature spoofing, where the permission is "dangerous" -->
-        <permission name="android.permission.FAKE_PACKAGE_SIGNATURE" fixed="false"/>
-    </exception>
+      <permission name="android.permission.ACCESS_COARSE_LOCATION"/>
+      <permission name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+      <permission name="android.permission.ACCESS_FINE_LOCATION"/>
+      <permission name="android.permission.SYSTEM_ALERT_WINDOW"/>
+   </exception>
 </exceptions>

--- a/GmsCore/microg.xml
+++ b/GmsCore/microg.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<map>
+    <boolean name="checkin_enable_service" value="false" />
+    <boolean name="gcm_enable_mcs_service" value="false" />
+    <boolean name="auth_manager_trust_google" value="true" />
+    <boolean name="auth_manager_visible" value="true" />
+    <boolean name="safetynet_enabled" value="false" />
+    <boolean name="droidguard_enabled" value="false" />
+    <boolean name="location_wifi_mls" value="true" />
+    <boolean name="location_wifi_moving" value="true" />
+    <boolean name="location_wifi_learning" value="true" />
+    <boolean name="location_cell_mls" value="true" />
+    <boolean name="location_cell_learning" value="true" />
+    <boolean name="location_geocoder_nominatim" value="true" />
+    <boolean name="exposure_scanner_enabled" value="false" />
+    <boolean name="wifi_mls" value="true" />
+    <boolean name="cell_mls" value="true" />
+    <boolean name="wifi_learning" value="true" />
+    <boolean name="cell_learning" value="true" />
+    <boolean name="wifi_moving" value="true" />
+    <boolean name="nominatim_enabled" value="true" />
+    <boolean name="vending_licensing" value="true" />
+    <boolean name="vending_licensing_purchase_free_apps" value="true" />
+    <boolean name="vending_billing" value="true" />
+    <boolean name="vending_asset_delivery" value="true" />
+</map>

--- a/GmsCore/privapp-permissions-com.google.android.gms.xml
+++ b/GmsCore/privapp-permissions-com.google.android.gms.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <permissions>
     <privapp-permissions package="com.google.android.gms">
-        <!-- for restrictive signature spoofing, where the permission is "signature|privileged" -->
-        <permission name="android.permission.FAKE_PACKAGE_SIGNATURE"/>
-
-        <permission name="android.permission.INSTALL_LOCATION_PROVIDER"/>
-        <permission name="android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST"/>
-        <permission name="android.permission.UPDATE_APP_OPS_STATS"/>
-        <permission name="android.permission.MANAGE_USB"/>
-    </privapp-permissions>
+      <permission name="android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST"/>
+      <permission name="android.permission.FOREGROUND_SERVICE"/>
+      <permission name="android.permission.INSTALL_LOCATION_PROVIDER"/>
+      <permission name="android.permission.LOCATION_HARDWARE"/>
+      <permission name="android.permission.MANAGE_USB"/>
+      <permission name="android.permission.MODIFY_PHONE_STATE"/>
+      <permission name="android.permission.NETWORK_SCAN"/>
+      <permission name="android.permission.READ_CONTACTS"/>
+      <permission name="android.permission.START_ACTIVITIES_FROM_BACKGROUND"/>
+      <permission name="android.permission.UPDATE_APP_OPS_STATS"/>
+      <permission name="android.permission.UPDATE_DEVICE_STATS"/>
+      <permission name="android.permission.WATCH_APPOPS"/>
+     </privapp-permissions>
 </permissions>


### PR DESCRIPTION
Fixes  Bootloops reported for several devices with December 21.0 builds #720 

Reused the content from [the IodéOS `vendor_extra` repo](https://gitlab.iode.tech/os/public/lineage/vendor_extra/-/tree/staging/prebuilts/GmsCore?ref_type=heads) - thanks Vincent 👍 

Tested by making a build for `xz2c` which clean flashes OK